### PR TITLE
Fix spelling in collector endpoint env variable

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,2 @@
-OTEL_COLLECOTR_ENDPOINT=ingest.{region}.signoz.cloud:443
+OTEL_COLLECTOR_ENDPOINT=ingest.{region}.signoz.cloud:443
 SIGNOZ_INGESTION_KEY=

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 ## Send logs from one host 
 
 
-* Add values of `OTEL_COLLECOTR_ENDPOINT` and `SIGNOZ_INGESTION_KEY` in the .env file
+* Add values of `OTEL_COLLECTOR_ENDPOINT` and `SIGNOZ_INGESTION_KEY` in the .env file

--- a/otel-collector-config.yaml
+++ b/otel-collector-config.yaml
@@ -23,7 +23,7 @@ processors:
     timeout: 10s
 exporters:
   otlp:
-    endpoint: ${env:OTEL_COLLECOTR_ENDPOINT}
+    endpoint: ${env:OTEL_COLLECTOR_ENDPOINT}
     tls:
       insecure: false
     headers:


### PR DESCRIPTION
Hi!
I found a spelling mistake in one of the configuration env variables.